### PR TITLE
Make array item to be sent as {value: item} in putMany

### DIFF
--- a/internal/services/base.js
+++ b/internal/services/base.js
@@ -58,7 +58,7 @@ class Base extends BaseService {
     const _items = [];
 
     items.map((item) => {
-      if (typeof item !== 'object') _items.push({ value: item });
+      if (typeof item !== 'object' || Array.isArray(item)) _items.push({ value: item });
       else _items.push(item);
     });
 


### PR DESCRIPTION
Arrays are objects, but need to be sent as {value: item}, so this condition needs also be triggered for arrays