### PR TITLE
:bug: stop assining fetch to global constant fetch

### DIFF
--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -1,8 +1,10 @@
 import fetch from 'node-fetch';
 
 // fetch polyfill for nodejs
-// @ts-ignore
-globalThis.fetch = fetch;
+if (!globalThis.fetch) {
+  // @ts-ignore
+  globalThis.fetch = fetch;
+}
 
 let app; // eslint-disable-line
 let App; // eslint-disable-line


### PR DESCRIPTION
I was trying to use Deta in my SvelteKit app and I've been getting this error:
``` shell
Cannot assign to read only property 'fetch' of object '#<Object>'
TypeError: Cannot assign to read only property 'fetch' of object '#<Object>'
    at Object.<anonymous> (/Users/nebula/Git/asanaetc/node_modules/deta/dist/index.js:752:18)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:14)
    at ModuleWrap.<anonymous> (internal/modules/esm/translators.js:199:29)
    at ModuleJob.run (internal/modules/esm/module_job.js:169:25)
    at async Loader.import (internal/modules/esm/loader.js:177:24)
    at async prerender (file:///Users/nebula/Git/asanaetc/node_modules/@sveltejs/kit/dist/chunks/index6.js:113:14)
    at async Object.prerender (file:///Users/nebula/Git/asanaetc/node_modules/@sveltejs/kit/dist/chunks/index6.js:339:5)
```

I've added if statement to check if `globalThis has fetch` before trying to assign polyfill `fetch` in it.
