### PR TITLE
fix drive get response to only return blob type

### DIFF
--- a/__test__/drive/get.spec.ts
+++ b/__test__/drive/get.spec.ts
@@ -3,11 +3,13 @@ import { Drive } from '../utils/deta';
 const drive = Drive();
 
 describe('Drive#get', () => {
+  const fileContent = '{"hello":"world"}';
+
   beforeAll(async () => {
     const inputs = ['get-a', 'get/a', 'get/child/a'];
 
     const promises = inputs.map(async (input) => {
-      const data = await drive.put(input, { data: 'hello' });
+      const data = await drive.put(input, { data: fileContent });
       expect(data).toEqual(input);
     });
 
@@ -30,6 +32,8 @@ describe('Drive#get', () => {
     async (name) => {
       const data = await drive.get(name as string);
       expect(data).not.toBeNull();
+      const value = await data?.text();
+      expect(value).toEqual(fileContent);
     }
   );
 

--- a/src/drive/drive.ts
+++ b/src/drive/drive.ts
@@ -58,7 +58,10 @@ export default class Drive {
     const encodedName = encodeURIComponent(trimmedName);
 
     const { status, response, error } = await this.requests.get(
-      DriveApi.GET_FILE.replace(':name', encodedName)
+      DriveApi.GET_FILE.replace(':name', encodedName),
+      {
+        blobResponse: true,
+      }
     );
     if (status === 404 && error) {
       return null;


### PR DESCRIPTION
Previously when the user was trying to get JSON files, `Drive#get` returned parsed JSON response, now it has been fixed to return Blob type instead (which is the expected behavior).